### PR TITLE
fix: use absolute path to sendemailservice endpoint on mapserv

### DIFF
--- a/widgets/notify/ChangeRequest.js
+++ b/widgets/notify/ChangeRequest.js
@@ -235,7 +235,7 @@ define([
             //     Deferred
             console.info('agrc.ijit.widgets.notify.ChangeRequest::_invokeWebService', arguments);
 
-            var url = '/sendemailservice/notify',
+            var url = 'https://mapserv.utah.gov/sendemailservice/notify',
                 ids = this.toIds || [2];
 
             if (ids.length < 1) {


### PR DESCRIPTION
Fixes: https://github.com/agrc/broadband/issues/83

I realize that this is not as conducive to local development. But this is super old code that just needs to work. I also think that it's more likely that a dev in the future will not have the send email service on his local machine.